### PR TITLE
Fix request payload encoding

### DIFF
--- a/sepy/ConnectionHandler.py
+++ b/sepy/ConnectionHandler.py
@@ -79,7 +79,7 @@ class ConnectionHandler:
         headers = {
             "Content-Type":"application/sparql-query" if isQuery else "application/sparql-update", 
             "Accept":"application/sparql-results+json"}
-        r = requests.post(reqURI, headers=headers, data=sparql)
+        r = requests.post(reqURI, headers=headers, data=sparql.encode('utf-8'))
         r.connection.close()
         return r.status_code, r.text
 
@@ -113,7 +113,7 @@ class ConnectionHandler:
            "Content-Type":"application/sparql-query" if isQuery else "application/sparql-update", 
            "Accept":"application/json",
            "Authorization": "Bearer " + self.token}
-        r = requests.post(reqURI, headers=headers, data=sparql, verify=False)        
+        r = requests.post(reqURI, headers=headers, data=sparql.encode('utf-8'), verify=False)        
         r.connection.close()
             
         # check for errors on token validity
@@ -146,7 +146,7 @@ class ConnectionHandler:
 
         # perform the request
         self.logger.debug("RegisterURI: {}".format(registerURI))
-        r = requests.post(registerURI, headers=headers, data=payload, verify=False)        
+        r = requests.post(registerURI, headers=headers, data=payload.encode('utf-8'), verify=False)        
         r.connection.close()
         
         if r.status_code == 201:


### PR DESCRIPTION
This PR fixes the problem which appears when the query/update payload contains non-ASCII characters such as àèéìòù.
Actually, it happened to me because I was querying covid19 data related to a place whose URI is the following:
http://covid19/Italy/Province/Forlì-Cesena

WebSocket messages are ok because they are always sent through a json.dumps(msg) method which should correctly handle the encoding.